### PR TITLE
NH-93485: add method to remove collector

### DIFF
--- a/metrics/src/main/java/com/solarwinds/joboe/metrics/MetricsCollector.java
+++ b/metrics/src/main/java/com/solarwinds/joboe/metrics/MetricsCollector.java
@@ -57,6 +57,10 @@ public class MetricsCollector extends SystemCollector<MetricsCategory, List<? ex
         collectors.put(category, collector);
     }
 
+    public void removeCollector(MetricsCategory category) {
+        collectors.remove(category);
+    }
+
     @Override
     protected Map<MetricsCategory, List<? extends MetricsEntry<?>>> collect() throws Exception {
         Map<MetricsCategory, Future<List<? extends MetricsEntry<?>>>> collectedFutures = new HashMap<MetricsCategory, Future<List<? extends MetricsEntry<?>>>>();

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>joboe</name>
 
     <properties>
-        <revision>10.0.13-SNAPSHOT</revision>
+        <revision>10.0.14-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
     </properties>


### PR DESCRIPTION
Adding this method so we can use it to remove metric collectors when exporting via `OTLP` to avoid duplication.