### PR TITLE
NH-103889: add new method for converting `Object` to proper type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>joboe</name>
 
     <properties>
-        <revision>10.0.18-SNAPSHOT</revision>
+        <revision>10.0.19-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
     </properties>

--- a/sampling/src/main/java/com/solarwinds/joboe/sampling/SettingsArg.java
+++ b/sampling/src/main/java/com/solarwinds/joboe/sampling/SettingsArg.java
@@ -1,5 +1,9 @@
 package com.solarwinds.joboe.sampling;
 
+import com.solarwinds.joboe.logging.Logger;
+import com.solarwinds.joboe.logging.LoggerFactory;
+import lombok.Getter;
+
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -7,10 +11,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.solarwinds.joboe.logging.Logger;
-import com.solarwinds.joboe.logging.LoggerFactory;
-import lombok.Getter;
 
 /**
  * Setting arguments used in {@link Settings}
@@ -59,6 +59,12 @@ public abstract class SettingsArg<T> {
      * @return
      */
     public abstract T readValue(ByteBuffer byteBuffer);
+
+
+    /**
+     * Converts the given {@link Object} to T
+     */
+    public abstract T readValue(Object object);
 
     /**
      * Reads the typed value of this SettingsArg and convert it to ByteBuffer
@@ -124,6 +130,18 @@ public abstract class SettingsArg<T> {
         }
 
         @Override
+        public Double readValue(Object object) {
+            if (object instanceof Integer) {
+                return ((Integer) object).doubleValue();
+
+            } else if (object instanceof Double) {
+                return (Double) object;
+            }
+
+            return null;
+        }
+
+        @Override
         public ByteBuffer toByteBuffer(Double value) {
             if (value != null) {
                 ByteBuffer buffer = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
@@ -154,6 +172,18 @@ public abstract class SettingsArg<T> {
             } finally {
                 byteBuffer.rewind();  //cast for JDK 8- runtime compatibility
             }
+        }
+
+        @Override
+        public Integer readValue(Object object) {
+            if (object instanceof Double) {
+                return ((Double) object).intValue();
+
+            } else if (object instanceof Integer) {
+                return (Integer) object;
+            }
+
+            return null;
         }
 
         @Override
@@ -190,6 +220,15 @@ public abstract class SettingsArg<T> {
         }
 
         @Override
+        public Boolean readValue(Object object) {
+            if (object instanceof Boolean) {
+                return (Boolean) object;
+            }
+
+            return null;
+        }
+
+        @Override
         public ByteBuffer toByteBuffer(Boolean value) {
             if (value != null) {
                 ByteBuffer buffer = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
@@ -220,6 +259,18 @@ public abstract class SettingsArg<T> {
             } finally {
                 byteBuffer.rewind();
             }
+        }
+
+        @Override
+        public byte[] readValue(Object object) {
+            if (object instanceof byte[]) {
+                return (byte[]) object;
+
+            } else if (object instanceof String) {
+                return ((String) object).getBytes();
+            }
+
+            return null;
         }
 
         @Override

--- a/sampling/src/test/java/com/solarwinds/joboe/sampling/SettingsArgTest.java
+++ b/sampling/src/test/java/com/solarwinds/joboe/sampling/SettingsArgTest.java
@@ -4,9 +4,12 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SettingsArgTest {
 
@@ -43,6 +46,38 @@ public class SettingsArgTest {
         buffer.putInt(0); //boolean uses int in bytebuffer (binary)
         buffer.flip();
         assertEquals(false, arg.readValue(buffer));
+    }
+
+    @Test
+    public void testDoubleSettingsArgReadValueWithObject() {
+        SettingsArg<Double> arg = new SettingsArg.DoubleSettingsArg("test-double");
+        assertEquals(3.0, arg.readValue(3), 0);
+        assertEquals(3.45, arg.readValue(3.45), 0);
+        assertNull(arg.readValue("3.0"));
+    }
+
+    @Test
+    public void testIntegerSettingsArgReadValueWithObject() {
+        SettingsArg<Integer> arg = new SettingsArg.IntegerSettingsArg("test-int");
+        assertEquals(3, arg.readValue(3));
+        assertEquals(3, arg.readValue(3.0));
+        assertNull(arg.readValue("3.0"));
+    }
+
+    @Test
+    public void testBooleanSettingsArgReadValueWithObject() {
+        SettingsArg<Boolean> arg = new SettingsArg.BooleanSettingsArg("test-boolean");
+        assertTrue(arg.readValue(true));
+        assertFalse(arg.readValue(false));
+        assertNull(arg.readValue("3.0"));
+    }
+
+    @Test
+    public void testByteSettingsArgReadValueWithObject() {
+        SettingsArg<byte[]> arg = new SettingsArg.ByteArraySettingsArg("test-bytes");
+        assertTrue(Arrays.equals(new byte[1], arg.readValue(new byte[1])));
+        assertTrue(Arrays.equals("bytes".getBytes(), arg.readValue("bytes")));
+        assertNull(arg.readValue(4));
     }
 
     @Test


### PR DESCRIPTION
Overload `readValue` method so it can also be used for Java root object. Needed for POJOs deserialized from JSON.